### PR TITLE
Use github.com/vimeo/go-clocks and update tests

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [macOS-latest, ubuntu-latest]
-        goversion: [1.12, 1.13]
+        goversion: [1.13, 1.14, 1.15]
     steps:
 
     - name: Set up Go ${{matrix.goversion}} on ${{matrix.os}}

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,8 @@
 module github.com/vimeo/go-retry
 
-require github.com/stretchr/testify v1.3.0
+require (
+	github.com/stretchr/testify v1.3.0
+	github.com/vimeo/go-clocks v1.0.0
+)
 
 go 1.13

--- a/go.sum
+++ b/go.sum
@@ -5,3 +5,5 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/vimeo/go-clocks v1.0.0 h1:d4bxmG2a6DMcr8IN7TZI1xI9T06NodwFfbKJx5+oXEg=
+github.com/vimeo/go-clocks v1.0.0/go.mod h1:coJz9AfolJ/xWbjgudyoJew7Kw/kV17P3fLIumNLjEg=


### PR DESCRIPTION
Also update the go versions list to include go 1.14 and 1.15 (and remove 1.12)