### PR TITLE
Wrapped Errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,13 +14,17 @@ func makeNetworkCall(ctx context.Context) {
     defaultBackoff := retry.DefaultBackoff()
 
     // try at most 5 times
-    retry.Retry(ctx, defaultBackoff, 5, func(ctx context.Context) error {
+    getErr := retry.Retry(ctx, defaultBackoff, 5, func(ctx context.Context) error {
         response, err := http.Get("https://my.favorite.service")
         if err != nil {
             return err
         }
         // do something with response...
     })
+
+    if getErr != nil {
+        // get failed, even after all the retries
+    }
 }
 ```
 

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/vimeo/go-retry
 
 require (
-	github.com/stretchr/testify v1.3.0
+	github.com/stretchr/testify v1.6.1
 	github.com/vimeo/go-clocks v1.0.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,13 @@ github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
-github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
-github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
+github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/vimeo/go-clocks v1.0.0 h1:d4bxmG2a6DMcr8IN7TZI1xI9T06NodwFfbKJx5+oXEg=
 github.com/vimeo/go-clocks v1.0.0/go.mod h1:coJz9AfolJ/xWbjgudyoJew7Kw/kV17P3fLIumNLjEg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
Provide wrapped errors so we can inspect what happened throughout the
process of retrying.

Also, update the testify dependency to its latest version.