### PR TITLE
retry: add retry.Typed that returns a value

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -8,11 +8,11 @@ jobs:
     strategy:
       matrix:
         os: [macOS-latest, ubuntu-latest]
-        goversion: [1.13, 1.14, 1.15]
+        goversion: [1.17, 1.18, 1.19]
     steps:
 
     - name: Set up Go ${{matrix.goversion}} on ${{matrix.os}}
-      uses: actions/setup-go@v1
+      uses: actions/setup-go@v3
       with:
         go-version: ${{matrix.goversion}}
       id: go
@@ -21,6 +21,7 @@ jobs:
       uses: actions/checkout@v1
 
     - name: gofmt
+      if: ${{matrix.goversion == '1.19'}}
       run: |
           [[ -z  $(gofmt -l $(find . -name '*.go') ) ]]
 

--- a/go.mod
+++ b/go.mod
@@ -5,4 +5,10 @@ require (
 	github.com/vimeo/go-clocks v1.0.0
 )
 
-go 1.13
+require (
+	github.com/davecgh/go-spew v1.1.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
+)
+
+go 1.18

--- a/go.sum
+++ b/go.sum
@@ -2,7 +2,6 @@ github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=

--- a/retry_generic_ret.go
+++ b/retry_generic_ret.go
@@ -1,0 +1,38 @@
+//   Copyright 2020 Vimeo
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+
+//go:build go1.18
+// +build go1.18
+
+package retry
+
+import (
+	"context"
+)
+
+// Typed provides a wrapper around the Retryable type that handles
+// arbitrary callback return-types in addition to an error.
+func Typed[T any](ctx context.Context, r *Retryable, f func(context.Context) (T, error)) (T, error) {
+	var ret T
+
+	err := r.Retry(ctx, func(ctx context.Context) error {
+		rv, callErr := f(ctx)
+		if callErr != nil {
+			return callErr
+		}
+		ret = rv
+		return nil
+	})
+	return ret, err
+}

--- a/retry_generic_ret_test.go
+++ b/retry_generic_ret_test.go
@@ -1,0 +1,58 @@
+//   Copyright 2020 Vimeo
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+
+//go:build go1.18
+// +build go1.18
+
+package retry
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTyped(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	c := make(chan struct{})
+	backoff := DefaultBackoff()
+	backoff.MinBackoff = time.Microsecond
+
+	go func() {
+		type retStruct struct {
+			a int
+			b string
+		}
+
+		q := 0
+		r := NewRetryable(18)
+		r.B = backoff
+		s, err := Typed(ctx, r, func(ctx context.Context) (retStruct, error) {
+			q++
+			if q == 2 {
+				return retStruct{a: 3, b: "fizzlebat"}, nil
+			}
+			return retStruct{}, fmt.Errorf("foo")
+		})
+		assert.NoError(t, err)
+		assert.Equal(t, 2, q)
+		assert.Equal(t, retStruct{a: 3, b: "fizzlebat"}, s)
+		close(c)
+	}()
+	<-c
+}


### PR DESCRIPTION
Add a more ergonomic `retry.Typed()` function that takes advantage of a
type-parameter to return an arbitrary value plus an error.

Update go.mod and github actions