### PR TITLE
Move to go 1.20 error slice unwrapping

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [macOS-latest, ubuntu-latest]
-        goversion: [1.17, 1.18, 1.19]
+        goversion: ['1.17', '1.18', '1.19', '1.20', '1.21', '1.22', '1.23', '1.24']
     steps:
 
     - name: Set up Go ${{matrix.goversion}} on ${{matrix.os}}

--- a/errors_unwrap_go1.19_earlier.go
+++ b/errors_unwrap_go1.19_earlier.go
@@ -1,0 +1,50 @@
+//   Copyright 2025 Vimeo
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+
+//go:build !go1.20
+
+package retry
+
+import "errors"
+
+// Unwrap returns the most recent error that occured during retrying.
+func (e *Errors) Unwrap() error {
+	if len(e.Errs) == 0 {
+		return nil
+	}
+	return e.Errs[len(e.Errs)-1]
+}
+
+// Is will return true if any of the underlying errors matches the target.  See
+// https://golang.org/pkg/errors/#Is
+func (e *Errors) Is(target error) bool {
+	for _, err := range e.Errs {
+		if errors.Is(err, target) {
+			return true
+		}
+	}
+	return false
+}
+
+// As will return true if any of the underlying errors matches the target and
+// sets the argument to that error specifically.  It returns false otherwise,
+// leaving the argument unchanged.  See https://golang.org/pkg/errors/#As
+func (e *Errors) As(target interface{}) bool {
+	for _, err := range e.Errs {
+		if errors.As(err, target) {
+			return true
+		}
+	}
+	return false
+}

--- a/errors_unwrap_go1.20.go
+++ b/errors_unwrap_go1.20.go
@@ -1,0 +1,29 @@
+//   Copyright 2025 Vimeo
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+
+//go:build go1.20
+
+package retry
+
+// Unwrap returns the errors that occured during retrying.
+func (e *Errors) Unwrap() []error {
+	if len(e.Errs) == 0 {
+		return nil
+	}
+	out := make([]error, len(e.Errs))
+	for i, err := range e.Errs {
+		out[i] = err
+	}
+	return out
+}

--- a/retry.go
+++ b/retry.go
@@ -16,7 +16,6 @@ package retry
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"time"
 
@@ -145,34 +144,6 @@ func (e *Error) Error() string {
 // Errors is a collection errors that happen across multiple retries.
 type Errors struct {
 	Errs []*Error
-}
-
-// Unwrap returns the most recent error that occured during retrying.
-func (e *Errors) Unwrap() error {
-	return e.Errs[len(e.Errs)-1]
-}
-
-// Is will return true if any of the underlying errors matches the target.  See
-// https://golang.org/pkg/errors/#Is
-func (e *Errors) Is(target error) bool {
-	for _, err := range e.Errs {
-		if errors.Is(err, target) {
-			return true
-		}
-	}
-	return false
-}
-
-// As will return true if any of the underlying errors matches the target and
-// sets the argument to that error specifically.  It returns false otherwise,
-// leaving the argument unchanged.  See https://golang.org/pkg/errors/#As
-func (e *Errors) As(target interface{}) bool {
-	for _, err := range e.Errs {
-		if errors.As(err, target) {
-			return true
-		}
-	}
-	return false
 }
 
 // Error implements the error interface.


### PR DESCRIPTION
Build tag it to continue supporting older versions of go.

Fix a bug in the old Unwrap() method's implementation that would panic
if there were zero errors listed, due to an out of bounds index.
